### PR TITLE
swiss: add correctness tests and improve benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,36 +12,51 @@ performance Go's builtin map for small map sizes, and significantly better
 performance at large map sizes.
 
 ```
-name                        old time/op  new time/op  delta
-StringMaps/n=16/map-10      7.19ns ± 3%  7.28ns ± 0%     ~     (p=0.154 n=9+9)
-StringMaps/n=128/map-10     7.66ns ± 5%  7.37ns ± 3%   -3.74%  (p=0.008 n=10+9)
-StringMaps/n=1024/map-10    10.8ns ± 3%   7.6ns ± 3%  -29.76%  (p=0.000 n=10+10)
-StringMaps/n=8192/map-10    20.3ns ± 2%   7.9ns ± 1%  -61.16%  (p=0.000 n=10+10)
-StringMaps/n=131072/map-10  26.1ns ± 0%  14.0ns ± 1%  -46.56%  (p=0.000 n=10+10)
-Int64Maps/n=16/map-10       4.96ns ± 1%  4.83ns ± 0%   -2.73%  (p=0.000 n=9+9)
-Int64Maps/n=128/map-10      5.19ns ± 3%  4.89ns ± 5%   -5.80%  (p=0.000 n=10+10)
-Int64Maps/n=1024/map-10     6.80ns ± 5%  5.01ns ± 2%  -26.32%  (p=0.000 n=10+10)
-Int64Maps/n=8192/map-10     17.4ns ± 1%   5.3ns ± 0%  -69.59%  (p=0.000 n=10+7)
-Int64Maps/n=131072/map-10   20.6ns ± 0%   6.7ns ± 0%  -67.67%  (p=0.000 n=10+9)
+name                                         old time/op  new time/op  delta
+StringMap/avgLoad,n=10/Map/Get-10            9.53ns ± 6%  8.43ns ± 1%  -11.50%  (p=0.000 n=10+9)
+StringMap/avgLoad,n=83/Map/Get-10            11.0ns ± 9%   9.2ns ±11%  -16.57%  (p=0.000 n=10+10)
+StringMap/avgLoad,n=671/Map/Get-10           15.7ns ± 3%   9.0ns ± 3%  -42.31%  (p=0.000 n=10+10)
+StringMap/avgLoad,n=5375/Map/Get-10          25.8ns ± 1%   9.3ns ± 1%  -63.88%  (p=0.000 n=10+10)
+StringMap/avgLoad,n=86015/Map/Get-10         30.5ns ± 1%  10.9ns ± 2%  -64.34%  (p=0.000 n=9+10)
+Int64Map/avgLoad,n=10/Map/Get-10             5.11ns ± 3%  4.85ns ± 1%   -5.13%  (p=0.000 n=10+10)
+Int64Map/avgLoad,n=83/Map/Get-10             5.23ns ± 3%  5.18ns ± 7%     ~     (p=0.529 n=10+10)
+Int64Map/avgLoad,n=671/Map/Get-10            6.03ns ± 7%  5.36ns ± 5%  -11.08%  (p=0.000 n=10+10)
+Int64Map/avgLoad,n=5375/Map/Get-10           18.3ns ± 2%   5.7ns ± 2%  -68.76%  (p=0.000 n=10+10)
+Int64Map/avgLoad,n=86015/Map/Get-10          23.9ns ± 1%   6.9ns ± 0%  -71.24%  (p=0.000 n=10+9)
+
+name                                         old time/op  new time/op  delta
+StringMap/avgLoad,n=10/Map/PutDelete-10      26.3ns ±11%  23.3ns ± 2%  -11.41%  (p=0.000 n=10+8)
+StringMap/avgLoad,n=83/Map/PutDelete-10      31.6ns ± 7%  23.4ns ± 4%  -25.94%  (p=0.000 n=10+10)
+StringMap/avgLoad,n=671/Map/PutDelete-10     45.2ns ± 1%  23.5ns ± 1%  -47.96%  (p=0.000 n=10+9)
+StringMap/avgLoad,n=5375/Map/PutDelete-10    56.7ns ± 1%  24.3ns ± 3%  -57.25%  (p=0.000 n=10+10)
+StringMap/avgLoad,n=86015/Map/PutDelete-10   60.9ns ± 0%  38.9ns ± 3%  -36.17%  (p=0.000 n=9+10)
+Int64Map/avgLoad,n=10/Map/PutDelete-10       18.4ns ± 9%  15.8ns ±12%  -13.99%  (p=0.000 n=10+10)
+Int64Map/avgLoad,n=83/Map/PutDelete-10       19.6ns ± 4%  14.7ns ± 1%  -25.14%  (p=0.000 n=9+8)
+Int64Map/avgLoad,n=671/Map/PutDelete-10      27.1ns ± 2%  14.2ns ± 3%  -47.52%  (p=0.000 n=10+9)
+Int64Map/avgLoad,n=5375/Map/PutDelete-10     44.4ns ± 1%  16.0ns ± 2%  -63.93%  (p=0.000 n=10+8)
+Int64Map/avgLoad,n=86015/Map/PutDelete-10    50.6ns ± 0%  21.6ns ± 3%  -57.41%  (p=0.000 n=9+10)
 ```
 
 ## Caveats
 
 - Resizing a `swiss.Map` is done for the whole table rather than the
-incremental resizing performed by Go's builtin map.
+  incremental resizing performed by Go's builtin map.
+- The implementation currently requires a little endian CPU architecture. This
+  is not a fundamental limitation of the implementation, merely a choice of
+  expediency.
 
 ## TODO
 
-- Add correctness tests.
 - Add support for rehash in-place.
-- Add support for SIMD searching on x86.
-- Add support for 8-byte Neon SIMD searching:
-  https://community.arm.com/arm-community-blogs/b/infrastructure-solutions-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon
-  https://github.com/abseil/abseil-cpp/commit/6481443560a92d0a3a55a31807de0cd712cd4f88
+- Add support for SIMD searching on x86 and (8-byte Neon SIMD searching on
+  arm64)[https://github.com/abseil/abseil-cpp/commit/6481443560a92d0a3a55a31807de0cd712cd4f88]
+  - This appears to be somewhat difficult. Naively implementing the match
+    routines in assembly isn't workable as the function call overhead
+    dominates the performance improvement form the SIMD comparisons. The
+    Abseil implementation is leveraring gcc/llvm assembly intrinsics which are
+    not currently available in Go. In order to take advantage of SIMD we'll
+    have to write most/all of the probing loop in assembly.
 - Abstract out the slice allocations so we can use manual memory allocation
   when used inside Pebble.
-- Benchmark insertion and deletion.
-- Add a note on thread safety (there isn't any).
-- Add a note that a little endian system is required, and a test that asserts that.
 - Explore extendible hashing to allow incremental resizing. See
   https://github.com/golang/go/issues/54766#issuecomment-1233125048

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+go test -v -run - -bench . -count 10 -timeout 1h | tee out
+grep -v swissMap out | sed 's,runtimeMap,Map,g' > out.runtime
+grep -v runtimeMap out | sed 's,swissMap,Map,g' > out.swiss
+benchstat out.runtime out.swiss

--- a/map.go
+++ b/map.go
@@ -66,36 +66,33 @@
 //
 // # Performance
 //
-// A swiss.Map has similar or slightly better performance than Go's builtin map
-// for small map sizes, and is much faster at large map sizes (old=go-map,
+// A swiss.Map has similar or slightly better performance than Go's builtin
+// map for small map sizes, and is much faster at large map sizes (old=go-map,
 // new=swissmap):
 //
-//	name                        old time/op  new time/op  delta
-//	StringMaps/n=16/map-10      7.19ns ± 3%  7.28ns ± 0%     ~     (p=0.154 n=9+9)
-//	StringMaps/n=128/map-10     7.66ns ± 5%  7.37ns ± 3%   -3.74%  (p=0.008 n=10+9)
-//	StringMaps/n=1024/map-10    10.8ns ± 3%   7.6ns ± 3%  -29.76%  (p=0.000 n=10+10)
-//	StringMaps/n=8192/map-10    20.3ns ± 2%   7.9ns ± 1%  -61.16%  (p=0.000 n=10+10)
-//	StringMaps/n=131072/map-10  26.1ns ± 0%  14.0ns ± 1%  -46.56%  (p=0.000 n=10+10)
-//	Int64Maps/n=16/map-10       4.96ns ± 1%  4.83ns ± 0%   -2.73%  (p=0.000 n=9+9)
-//	Int64Maps/n=128/map-10      5.19ns ± 3%  4.89ns ± 5%   -5.80%  (p=0.000 n=10+10)
-//	Int64Maps/n=1024/map-10     6.80ns ± 5%  5.01ns ± 2%  -26.32%  (p=0.000 n=10+10)
-//	Int64Maps/n=8192/map-10     17.4ns ± 1%   5.3ns ± 0%  -69.59%  (p=0.000 n=10+7)
-//	Int64Maps/n=131072/map-10   20.6ns ± 0%   6.7ns ± 0%  -67.67%  (p=0.000 n=10+9)
+//	name                                         old time/op  new time/op  delta
+//	StringMap/avgLoad,n=10/Map/Get-10            9.53ns ± 6%  8.43ns ± 1%  -11.50%  (p=0.000 n=10+9)
+//	StringMap/avgLoad,n=83/Map/Get-10            11.0ns ± 9%   9.2ns ±11%  -16.57%  (p=0.000 n=10+10)
+//	StringMap/avgLoad,n=671/Map/Get-10           15.7ns ± 3%   9.0ns ± 3%  -42.31%  (p=0.000 n=10+10)
+//	StringMap/avgLoad,n=5375/Map/Get-10          25.8ns ± 1%   9.3ns ± 1%  -63.88%  (p=0.000 n=10+10)
+//	StringMap/avgLoad,n=86015/Map/Get-10         30.5ns ± 1%  10.9ns ± 2%  -64.34%  (p=0.000 n=9+10)
+//	Int64Map/avgLoad,n=10/Map/Get-10             5.11ns ± 3%  4.85ns ± 1%   -5.13%  (p=0.000 n=10+10)
+//	Int64Map/avgLoad,n=83/Map/Get-10             5.23ns ± 3%  5.18ns ± 7%     ~     (p=0.529 n=10+10)
+//	Int64Map/avgLoad,n=671/Map/Get-10            6.03ns ± 7%  5.36ns ± 5%  -11.08%  (p=0.000 n=10+10)
+//	Int64Map/avgLoad,n=5375/Map/Get-10           18.3ns ± 2%   5.7ns ± 2%  -68.76%  (p=0.000 n=10+10)
+//	Int64Map/avgLoad,n=86015/Map/Get-10          23.9ns ± 1%   6.9ns ± 0%  -71.24%  (p=0.000 n=10+9)
 //
-// A swiss.Map dominates the performance of the RobinHood map used by Pebble's
-// block-cache (old=robinhood, new=swissmap):
-//
-//	name                        old time/op  new time/op  delta
-//	StringMaps/n=16/map-10      11.7ns ±28%   7.3ns ± 0%  -37.68%  (p=0.000 n=10+9)
-//	StringMaps/n=128/map-10     12.6ns ± 5%   7.4ns ± 3%  -41.44%  (p=0.000 n=9+9)
-//	StringMaps/n=1024/map-10    14.1ns ± 7%   7.6ns ± 3%  -46.30%  (p=0.000 n=10+10)
-//	StringMaps/n=8192/map-10    17.7ns ± 4%   7.9ns ± 1%  -55.39%  (p=0.000 n=10+10)
-//	StringMaps/n=131072/map-10  25.5ns ± 1%  14.0ns ± 1%  -45.20%  (p=0.000 n=10+10)
-//	Int64Maps/n=16/map-10       4.96ns ± 7%  4.83ns ± 0%   -2.72%  (p=0.012 n=10+9)
-//	Int64Maps/n=128/map-10      4.92ns ± 4%  4.89ns ± 5%     ~     (p=0.085 n=10+10)
-//	Int64Maps/n=1024/map-10     5.63ns ± 5%  5.01ns ± 2%  -11.02%  (p=0.000 n=10+10)
-//	Int64Maps/n=8192/map-10     11.1ns ± 4%   5.3ns ± 0%  -52.46%  (p=0.000 n=10+7)
-//	Int64Maps/n=131072/map-10   14.3ns ± 1%   6.7ns ± 0%  -53.33%  (p=0.000 n=10+9)
+//	name                                         old time/op  new time/op  delta
+//	StringMap/avgLoad,n=10/Map/PutDelete-10      26.3ns ±11%  23.3ns ± 2%  -11.41%  (p=0.000 n=10+8)
+//	StringMap/avgLoad,n=83/Map/PutDelete-10      31.6ns ± 7%  23.4ns ± 4%  -25.94%  (p=0.000 n=10+10)
+//	StringMap/avgLoad,n=671/Map/PutDelete-10     45.2ns ± 1%  23.5ns ± 1%  -47.96%  (p=0.000 n=10+9)
+//	StringMap/avgLoad,n=5375/Map/PutDelete-10    56.7ns ± 1%  24.3ns ± 3%  -57.25%  (p=0.000 n=10+10)
+//	StringMap/avgLoad,n=86015/Map/PutDelete-10   60.9ns ± 0%  38.9ns ± 3%  -36.17%  (p=0.000 n=9+10)
+//	Int64Map/avgLoad,n=10/Map/PutDelete-10       18.4ns ± 9%  15.8ns ±12%  -13.99%  (p=0.000 n=10+10)
+//	Int64Map/avgLoad,n=83/Map/PutDelete-10       19.6ns ± 4%  14.7ns ± 1%  -25.14%  (p=0.000 n=9+8)
+//	Int64Map/avgLoad,n=671/Map/PutDelete-10      27.1ns ± 2%  14.2ns ± 3%  -47.52%  (p=0.000 n=10+9)
+//	Int64Map/avgLoad,n=5375/Map/PutDelete-10     44.4ns ± 1%  16.0ns ± 2%  -63.93%  (p=0.000 n=10+8)
+//	Int64Map/avgLoad,n=86015/Map/PutDelete-10    50.6ns ± 0%  21.6ns ± 3%  -57.41%  (p=0.000 n=9+10)
 //
 // # Caveats
 //
@@ -136,6 +133,8 @@ type slot[K comparable, V any] struct {
 // Map is an unordered map from keys to values with Put, Get, Delete, and All
 // operations. It is inspired by Google's Swiss Tables design as implemented
 // in Abseil's flat_hash_map.
+//
+// A Map is NOT goroutine-safe.
 type Map[K comparable, V any] struct {
 	// ctrls is capacity+groupSize in length. Ctrls[capacity] is always
 	// ctrlSentinel which is used to stop probe iteration. A copy of the first
@@ -171,14 +170,20 @@ type Map[K comparable, V any] struct {
 // initialCapacity is 0 the map will start out with zero capacity and will
 // grow on the first insert. The zero value for an M is not usable.
 func New[K comparable, V any](initialCapacity int) *Map[K, V] {
+	// The ctrls for an empty map points to emptyCtrls which simplifies
+	// probing in Get, Put, and Delete. The emptyCtrls never match a probe
+	// operation, but because growthLeft == 0 if we try to insert we'll
+	// immediately rehash and grow.
 	m := &Map[K, V]{
 		ctrls: emptyCtrls,
 		hash:  getRuntimeHasher[K](),
 		seed:  uintptr(fastrand64()),
 	}
 	if initialCapacity > 0 {
-		targetCapacity := (1 << (uint(bits.Len(uint(2*initialCapacity-1))) - 1)) - 1
-		m.rehash(uintptr(targetCapacity))
+		// targetCapacity is the smallest value of the form 2^k-1 that is >=
+		// initialCapacity.
+		targetCapacity := (uintptr(1) << bits.Len(uint(initialCapacity))) - 1
+		m.resize(targetCapacity)
 	}
 	return m
 }
@@ -464,11 +469,47 @@ func (m *Map[K, V]) wasNeverFull(i uintptr) bool {
 	indexBefore := (i - groupSize) & m.capacity
 	emptyAfter := m.ctrls.At(i).matchEmpty()
 	emptyBefore := m.ctrls.At(indexBefore).matchEmpty()
+	if debug {
+		fmt.Printf("wasNeverFull: before=%d/%s/%d after=%d/%s/%d\n",
+			indexBefore, emptyBefore, bits.LeadingZeros64(uint64(emptyBefore))>>3,
+			i, emptyAfter, bits.TrailingZeros64(uint64(emptyAfter))>>3)
+	}
+
 	// We count how many consecutive non empties we have to the right and to
 	// the left of i. If the sum is >= groupSize then there is at least one
 	// probe window that might have seen a full group.
+	//
+	// We're looking at the control bytes on either side of i trying to
+	// determine if the control byte i ever overlapped with a group that was
+	// full:
+	//
+	//   xx xx xx xx xx xx xx xx  xx xx xx xx xx xx xx xx
+	//   ^                        ^
+	//   indexBefore              i
+	//
+	// The matchEmpty calls will transform the control bytes into either 0x80
+	// if the control byte was empty, or 0x00 if the control byte was full,
+	// deleted, or the sentinel. Consider the case where the control byte
+	// immediately to the left of i is empty and all of the other control
+	// bytes are full:
+	//
+	//   00 00 00 80 00 00 00 00  00 00 00 00 80 00 00 00
+	//   ^                        ^
+	//   indexBefore              i
+	//
+	// The empty{Before,After} != 0 checks are a quick test to see if the
+	// group starting at indexBefore and i are completely full. In this case,
+	// both emptyBefore and emptyAfter are non-zero. (TODO: are these quick
+	// checks worthwhile, they aren't necessary for correctness). We count the
+	// number of trailing zero bits in emptyBefore (39), and divide by 8 (the
+	// number of bits in a byte) to identify the first empty byte to the left
+	// of i as 4. Similarly, we count the number of leading zeros in
+	// emptyBefore (32) and divide by 8 to find the first empty byte to the
+	// right of i as 4. Sum these two results together and we see there was a
+	// full group overlapping i.
 	if emptyBefore != 0 && emptyAfter != 0 &&
-		(emptyBefore.count()+emptyAfter.count()) < groupSize {
+		((bits.TrailingZeros64(uint64(emptyAfter))>>3)+
+			(bits.LeadingZeros64(uint64(emptyBefore))>>3)) < groupSize {
 		return true
 	}
 	return false
@@ -482,13 +523,7 @@ func (m *Map[K, V]) uncheckedPut(h uintptr, key K, value V) {
 	// overcrowded (i.e. the load factor is greater than 7/8 for big tables;
 	// small tables use a max load factor of 1).
 	if m.growthLeft == 0 {
-		// TODO(peter): We only have to rehash if the slot we're trying to
-		// insert into isn't deleted. Abseil handles this by first finding the
-		// slot to insert into and only resizing if that slot is not deleted.
-		// After resizing it has to re-find the slot to insert into, though
-		// the table should be <50% empty so the first group it checks should
-		// have an empty slot.
-		m.rehash(2*m.capacity + 1)
+		m.rehash()
 	}
 
 	// Given key and its hash hash(key), to insert it, we construct a
@@ -523,16 +558,35 @@ func (m *Map[K, V]) uncheckedPut(h uintptr, key K, value V) {
 	}
 }
 
-// rehash resize the capacity of the table by allocating a bigger array and
+func (m *Map[K, V]) rehash() {
+	// Rehash in place if the current used slots is <= 25/32 of capacity. The
+	// 25/32 heuristic comes from Abseil's implementation.
+	//
+	// The rationale for such a high factor: 1) rehashInPlace() is faster than
+	// resize(), and 2) it takes quite a bit of work to add tombstones. In the
+	// worst case it seems to take approximately 4 Put/Delete pairs to create
+	// a single tombstone. If we are rehashing because of tombstones we can
+	// afford to rehash-in-place as long as we are reclaiming at least 1/8 the
+	// capacity without doing more than 2X the work (where "work" is defined
+	// to be m.used for rehashing or rehashing in place, and 1 for an Put or
+	// Delete). But rehashing in place is faster per operation than inserting
+	// or even doubling the size of the table, so we actually afford to
+	// reclaim even less space from a rehash-in-place. The decision is to
+	// rehash in place if we can reclaim at about 1/8th of the usable capacity
+	// (specifically 3/28 of the capacity) which means that the total cost of
+	// rehashing will be a small fraction of the total work.
+	if false && uint64(m.used)*32 <= uint64(m.capacity)*25 { // 64-bit calcs to avoid overflow
+		m.rehashInPlace()
+	} else {
+		m.resize(2*m.capacity + 1)
+	}
+}
+
+// resize resize the capacity of the table by allocating a bigger array and
 // uncheckedPutting each element of the table into the new array (we know that
 // no insertion here will Put an already-present value), and discard the old
 // backing array.
-func (m *Map[K, V]) rehash(newCapacity uintptr) {
-	// TODO(peter): rehash in place if there are a sufficient number of
-	// tombstones to reclaim. See drop_deletes_without_resize() in the abseil
-	// implementation:
-	// https://github.com/abseil/abseil-cpp/blob/master/absl/container/internal/raw_hash_set.h#L311
-
+func (m *Map[K, V]) resize(newCapacity uintptr) {
 	if (1 + newCapacity) < groupSize {
 		newCapacity = groupSize - 1
 	}
@@ -573,6 +627,14 @@ func (m *Map[K, V]) rehash(newCapacity uintptr) {
 	}
 }
 
+func (m *Map[K, V]) rehashInPlace() {
+	// TODO(peter): rehash in place if there are a sufficient number of
+	// tombstones to reclaim. See drop_deletes_without_resize() in the abseil
+	// implementation:
+	// https://github.com/abseil/abseil-cpp/blob/master/absl/container/internal/raw_hash_set.h#L311
+	panic("TODO(peter): unimplemented")
+}
+
 type bitset uint64
 
 func (b bitset) next() uintptr {
@@ -581,10 +643,6 @@ func (b bitset) next() uintptr {
 
 func (b bitset) clear(i uintptr) bitset {
 	return b &^ (bitset(0x80) << (i << 3))
-}
-
-func (b bitset) count() int {
-	return bits.OnesCount64(uint64(b))
 }
 
 func (b bitset) String() string {
@@ -619,6 +677,12 @@ var emptyCtrls = func() unsafeSlice[ctrl] {
 }()
 
 func (c *ctrl) matchH2(h uintptr) bitset {
+	// NB: This generic matching routine produces false positive matches when
+	// h is 2^N and the control bytes have a seq of 2^N followed by 2^N+1. For
+	// example: if ctrls==0x0302 and h=02, we'll compute v as 0x0100. When we
+	// subtract off 0x0101 the first 2 bytes we'll become 0xffff and both be
+	// considered matches of h. The false positive matches are not a problem,
+	// just a rare inefficiency.
 	v := *(*uint64)((unsafe.Pointer)(c)) ^ (bitsetLSB * uint64(h))
 	return bitset(((v - bitsetLSB) &^ v) & bitsetMSB)
 }
@@ -626,11 +690,6 @@ func (c *ctrl) matchH2(h uintptr) bitset {
 func (c *ctrl) matchEmpty() bitset {
 	v := *(*uint64)((unsafe.Pointer)(c))
 	return bitset((v &^ (v << 6)) & bitsetMSB)
-}
-
-func (c *ctrl) matchFull() bitset {
-	v := *(*uint64)((unsafe.Pointer)(c))
-	return bitset((v ^ bitsetMSB) & bitsetMSB)
 }
 
 func (c *ctrl) matchEmptyOrDeleted() bitset {
@@ -664,7 +723,7 @@ type probeSeq struct {
 	index  uintptr
 }
 
-func makeProbeSeq(hash uintptr, mask uintptr) probeSeq {
+func makeProbeSeq(hash, mask uintptr) probeSeq {
 	return probeSeq{
 		mask:   mask,
 		offset: hash & mask,

--- a/map_test.go
+++ b/map_test.go
@@ -2,128 +2,513 @@ package swiss
 
 import (
 	"fmt"
-	"math/bits"
 	"math/rand"
-	"strconv"
+	"sort"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TODO(peter)
-// - Insertion
-// - Deletion
-// - Lookup hit vs lookup miss
-// - Resizing
-// - Dropping tombstones without resizing
-// - Iteration
-// - Iteration while mutating the map
+// toBuiltinMap returns the elements as a map[K]V. Useful for testing.
+func (m *Map[K, V]) toBuiltinMap() map[K]V {
+	r := make(map[K]V)
+	m.All(func(k K, v V) bool {
+		r[k] = v
+		return true
+	})
+	return r
+}
+
+// TODO(peter): Extracting a random element might be generally useful. Should
+// this be promoted to the public API?
+func (m *Map[K, V]) randElement() (key K, value V, ok bool) {
+	if m.capacity > 0 {
+		offset := uintptr(rand.Intn(int(m.capacity)))
+		for i := uintptr(0); i <= m.capacity; i++ {
+			j := (i + offset) & m.capacity
+			if (*m.ctrls.At(j) & ctrlEmpty) != ctrlEmpty {
+				s := m.slots.At(j)
+				return s.key, s.value, true
+			}
+		}
+	}
+	return key, value, false
+}
+
+func TestLittleEndian(t *testing.T) {
+	// The implementation of group h2 matching and group empty and deleted
+	// masking assumes a little endian CPU architecture. Assert that we are
+	// running on one.
+	b := []uint8{0x1, 0x2, 0x3, 0x4}
+	v := *(*uint32)(unsafe.Pointer(&b[0]))
+	require.EqualValues(t, 0x04030201, v)
+}
+
+func TestProbeSeq(t *testing.T) {
+	genSeq := func(n int, hash, mask uintptr) []uintptr {
+		seq := makeProbeSeq(hash, mask)
+		vals := make([]uintptr, n)
+		for i := 0; i < n; i++ {
+			vals[i] = seq.offset
+			seq = seq.next()
+		}
+		return vals
+	}
+	genGroups := func(n int, start, count uintptr) []uintptr {
+		var vals []uintptr
+		for i := start % groupSize; i < count; i += groupSize {
+			vals = append(vals, i)
+		}
+		sort.Slice(vals, func(i, j int) bool {
+			return vals[i] < vals[j]
+		})
+		return vals
+	}
+
+	// The Abseil probeSeq test cases.
+	expected := []uintptr{0, 8, 24, 48, 80, 120, 40, 96, 32, 104, 56, 16, 112, 88, 72, 64}
+	require.Equal(t, expected, genSeq(16, 0, 127))
+	require.Equal(t, expected, genSeq(16, 128, 127))
+
+	// Verify that we touch all of the groups no matter what our start offset
+	// within the group is.
+	for i := uintptr(0); i < 128; i++ {
+		vals := genSeq(16, i, 127)
+		require.Equal(t, 16, len(vals))
+		sort.Slice(vals, func(i, j int) bool {
+			return vals[i] < vals[j]
+		})
+		require.Equal(t, genGroups(16, i, 128), vals)
+	}
+}
+
+func TestMatchH2(t *testing.T) {
+	ctrls := []ctrl{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}
+	for i := uintptr(1); i <= 8; i++ {
+		match := ctrls[0].matchH2(i)
+		bit := match.next()
+		require.EqualValues(t, i-1, bit)
+	}
+}
+
+func TestMatchEmpty(t *testing.T) {
+	testCases := []struct {
+		ctrls    []ctrl
+		expected []uintptr
+	}{
+		{[]ctrl{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}, nil},
+		{[]ctrl{0x1, 0x2, 0x3, ctrlEmpty, 0x5, ctrlDeleted, 0x7, ctrlSentinel}, []uintptr{3}},
+		{[]ctrl{0x1, 0x2, 0x3, ctrlEmpty, 0x5, 0x6, ctrlEmpty, 0x8}, []uintptr{3, 6}},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			match := c.ctrls[0].matchEmpty()
+			var results []uintptr
+			for match != 0 {
+				bit := match.next()
+				results = append(results, bit)
+				match = match.clear(bit)
+			}
+			require.Equal(t, c.expected, results)
+		})
+	}
+}
+
+func TestMatchEmptyOrDeleted(t *testing.T) {
+	testCases := []struct {
+		ctrls    []ctrl
+		expected []uintptr
+	}{
+		{[]ctrl{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}, nil},
+		{[]ctrl{0x1, 0x2, ctrlEmpty, ctrlDeleted, 0x5, 0x6, 0x7, ctrlSentinel}, []uintptr{2, 3}},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			match := c.ctrls[0].matchEmptyOrDeleted()
+			var results []uintptr
+			for match != 0 {
+				bit := match.next()
+				results = append(results, bit)
+				match = match.clear(bit)
+			}
+			require.Equal(t, c.expected, results)
+		})
+	}
+}
+
+func TestWasNeverFull(t *testing.T) {
+	m := &Map[int, int]{
+		capacity: 15,
+		ctrls:    makeUnsafeSlice(make([]ctrl, 16)),
+	}
+
+	testCases := []struct {
+		emptyIndexes []uintptr
+		expected     bool
+	}{
+		{[]uintptr{}, false},
+		{[]uintptr{0}, false},
+		{[]uintptr{0, 15}, true},
+		{[]uintptr{1, 15}, true},
+		{[]uintptr{2, 15}, true},
+		{[]uintptr{3, 15}, true},
+		{[]uintptr{4, 15}, true},
+		{[]uintptr{5, 15}, true},
+		{[]uintptr{6, 15}, true},
+		{[]uintptr{7, 15}, true},
+		{[]uintptr{8, 15}, false},
+		{[]uintptr{0, 14}, true},
+		{[]uintptr{0, 13}, true},
+		{[]uintptr{0, 12}, true},
+		{[]uintptr{0, 11}, true},
+		{[]uintptr{0, 10}, true},
+		{[]uintptr{0, 9}, true},
+		{[]uintptr{0, 8}, true},
+		{[]uintptr{0, 7}, false},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			for i := uintptr(0); i < 16; i++ {
+				*m.ctrls.At(i) = 0
+			}
+			for _, i := range c.emptyIndexes {
+				*m.ctrls.At(i) = ctrlEmpty
+			}
+			require.Equal(t, c.expected, m.wasNeverFull(0))
+		})
+	}
+}
+
+func TestInitialCapacity(t *testing.T) {
+	testCases := []struct {
+		initialCapacity  int
+		expectedCapacity int
+	}{
+		{0, 0},
+		{1, 7},
+		{7, 7},
+		{8, 15},
+		{1000, 1023},
+		{1024, 2047},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			m := New[int, int](c.initialCapacity)
+			require.EqualValues(t, c.expectedCapacity, m.capacity)
+		})
+	}
+}
 
 func TestBasic(t *testing.T) {
+	goodHash := func() *Map[int, int] {
+		return New[int, int](0)
+	}
+	badHash := func() *Map[int, int] {
+		m := goodHash()
+		m.hash = func(key unsafe.Pointer, seed uintptr) uintptr {
+			return 0
+		}
+		return m
+	}
+
+	for _, m := range []*Map[int, int]{goodHash(), badHash()} {
+		t.Run("", func(t *testing.T) {
+			e := make(map[int]int)
+			require.EqualValues(t, 0, m.Len())
+			require.EqualValues(t, 0, m.growthLeft)
+
+			// Non-existent.
+			for i := 0; i < 10; i++ {
+				_, ok := m.Get(i)
+				require.False(t, ok)
+			}
+
+			// Insert.
+			for i := 0; i < 10; i++ {
+				m.Put(i, i+10)
+				e[i] = i + 10
+				v, ok := m.Get(i)
+				require.True(t, ok)
+				require.EqualValues(t, i+10, v)
+				require.EqualValues(t, i+1, m.Len())
+				require.Equal(t, e, m.toBuiltinMap())
+			}
+
+			// Update.
+			for i := 0; i < 10; i++ {
+				m.Put(i, i+20)
+				e[i] = i + 20
+				v, ok := m.Get(i)
+				require.True(t, ok)
+				require.EqualValues(t, i+20, v)
+				require.EqualValues(t, 10, m.Len())
+				require.Equal(t, e, m.toBuiltinMap())
+			}
+
+			// Delete.
+			for i := 0; i < 10; i++ {
+				m.Delete(i)
+				delete(e, i)
+				require.EqualValues(t, 10-i-1, m.Len())
+				_, ok := m.Get(i)
+				require.False(t, ok)
+				require.Equal(t, e, m.toBuiltinMap())
+			}
+		})
+	}
+}
+
+func TestRandom(t *testing.T) {
+	goodHash := func() *Map[int, int] {
+		return New[int, int](0)
+	}
+	badHash := func() *Map[int, int] {
+		m := goodHash()
+		m.hash = func(key unsafe.Pointer, seed uintptr) uintptr {
+			return 0
+		}
+		return m
+	}
+
+	for _, m := range []*Map[int, int]{goodHash(), badHash()} {
+		t.Run("", func(t *testing.T) {
+			e := make(map[int]int)
+			for i := 0; i < 10000; i++ {
+				switch r := rand.Float64(); {
+				case r < 0.5: // 50% inserts
+					k, v := rand.Int(), rand.Int()
+					if debug {
+						fmt.Printf("insert %d: %d\n", k, v)
+					}
+					m.Put(k, v)
+					e[k] = v
+				case r < 0.65: // 15% updates
+					if k, _, ok := m.randElement(); !ok {
+						require.EqualValues(t, 0, m.Len(), e)
+					} else {
+						v := rand.Int()
+						if debug {
+							fmt.Printf("update %d: %d\n", k, v)
+						}
+						m.Put(k, v)
+						e[k] = v
+					}
+				case r < 0.80: // 15% deletes
+					if k, _, ok := m.randElement(); !ok {
+						require.EqualValues(t, 0, m.Len(), e)
+					} else {
+						if debug {
+							fmt.Printf("delete %d\n", k)
+						}
+						m.Delete(k)
+						delete(e, k)
+					}
+				case r < 0.95: // 25% lookups
+					if k, v, ok := m.randElement(); !ok {
+						require.EqualValues(t, 0, m.Len(), e)
+					} else {
+						if debug {
+							fmt.Printf("lookup %d: %d vs %d\n", k, e[k], v)
+						}
+						require.EqualValues(t, e[k], v)
+					}
+				default: // 5% iteration
+					require.Equal(t, e, m.toBuiltinMap())
+				}
+				require.EqualValues(t, len(e), m.Len())
+			}
+		})
+	}
+}
+
+func TestIterateMutate(t *testing.T) {
 	m := New[int, int](0)
-	for i := 0; i < 10; i++ {
-		m.Put(i, i+10)
-		if v, ok := m.Get(i); ok {
-			fmt.Printf("%d\n", v)
-		}
+	for i := 0; i < 100; i++ {
+		m.Put(i, i)
 	}
-	for i := 0; i < 10; i++ {
-		m.Delete(i)
-		if v, ok := m.Get(i); ok {
-			fmt.Printf("%d\n", v)
+	e := m.toBuiltinMap()
+	require.EqualValues(t, 100, m.Len())
+	require.EqualValues(t, 100, len(e))
+
+	// Iterate over the map, resizing it periodically. We should see all of
+	// the elements that were originally in the map because All takes a
+	// snapshot of the ctrls and slots before iterating.
+	vals := make(map[int]int)
+	m.All(func(k, v int) bool {
+		if (k % 10) == 0 {
+			m.resize(2*m.capacity + 1)
+		}
+		vals[k] = v
+		return true
+	})
+	require.EqualValues(t, e, vals)
+}
+
+func BenchmarkStringMap(b *testing.B) {
+	const stringKeyLen = 8
+
+	genStringData := func(count int) []string {
+		src := rand.New(rand.NewSource(int64(stringKeyLen * count)))
+		letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+		r := make([]rune, stringKeyLen*count)
+		for i := range r {
+			r[i] = letters[src.Intn(len(letters))]
+		}
+		keys := make([]string, count)
+		for i := range keys {
+			keys[i] = string(r[:stringKeyLen])
+			r = r[stringKeyLen:]
+		}
+		return keys
+	}
+
+	sizes := []int{16, 128, 1024, 8192, 131072}
+	for _, size := range sizes {
+		// Test sizes that result in the max, min, and avg loads for swiss.Map.
+		minLoad := size * 7 / 8
+		maxLoad := minLoad - 1
+		avgLoad := ((size/2)*7/8 + maxLoad) / 2
+
+		loadType := []string{"avgLoad", "maxLoad", "minLoad"}
+		for i, n := range []int{avgLoad, maxLoad, minLoad} {
+			b.Run(fmt.Sprintf("%s,n=%d", loadType[i], n), func(b *testing.B) {
+				b.Run("runtimeMap", func(b *testing.B) {
+					benchmarkRuntimeMap(b, genStringData(n))
+				})
+				b.Run("swissMap", func(b *testing.B) {
+					benchmarkSwissMap(b, genStringData(n))
+				})
+			})
 		}
 	}
 }
 
-func BenchmarkStringMaps(b *testing.B) {
-	const keySz = 8
-	sizes := []int{16, 128, 1024, 8192, 131072}
-	for _, n := range sizes {
-		b.Run("n="+strconv.Itoa(n), func(b *testing.B) {
-			b.Run("runtime map", func(b *testing.B) {
-				benchmarkRuntimeMap(b, genStringData(keySz, n))
-			})
-			b.Run("swissmap", func(b *testing.B) {
-				benchmarkSwissMap(b, genStringData(keySz, n))
-			})
-		})
+func BenchmarkInt64Map(b *testing.B) {
+	genInt64Data := func(n int) []int64 {
+		keys := make([]int64, n)
+		var x int64
+		for i := range keys {
+			x += rand.Int63n(128) + 1
+			keys[i] = x
+		}
+		return keys
 	}
-}
 
-func BenchmarkInt64Maps(b *testing.B) {
 	sizes := []int{16, 128, 1024, 8192, 131072}
-	for _, n := range sizes {
-		b.Run("n="+strconv.Itoa(n), func(b *testing.B) {
-			b.Run("runtime map", func(b *testing.B) {
-				benchmarkRuntimeMap(b, genInt64Data(n))
+	for _, size := range sizes {
+		// Test sizes that result in the max, min, and avg loads for swiss.Map.
+		minLoad := size * 7 / 8
+		maxLoad := minLoad - 1
+		avgLoad := ((size/2)*7/8 + maxLoad) / 2
+
+		loadType := []string{"avgLoad", "maxLoad", "minLoad"}
+		for i, n := range []int{avgLoad, maxLoad, minLoad} {
+			b.Run(fmt.Sprintf("%s,n=%d", loadType[i], n), func(b *testing.B) {
+				b.Run("runtimeMap", func(b *testing.B) {
+					benchmarkRuntimeMap(b, genInt64Data(n))
+				})
+				b.Run("swissMap", func(b *testing.B) {
+					benchmarkSwissMap(b, genInt64Data(n))
+				})
 			})
-			b.Run("swissmap", func(b *testing.B) {
-				benchmarkSwissMap(b, genInt64Data(n))
-			})
-		})
+		}
 	}
 }
 
 func benchmarkRuntimeMap[K comparable](b *testing.B, keys []K) {
 	n := uint32(len(keys))
-	mod := n - 1 // power of 2 fast modulus
-	require.Equal(b, 1, bits.OnesCount32(n))
-	m := make(map[K]K, n)
-	for _, k := range keys {
-		m[k] = k
+
+	// Go's builtin map has an optimization to avoid string comparisons if
+	// there is pointer equality. Defeat this optimization to get a better
+	// apples-to-apples comparison. This is reasonable to do because looking
+	// up a value by a string key which shares the underlying string data with
+	// the element in the map is a rare pattern.
+	cloneKeys := func(keys []K) []K {
+		var k K
+		switch any(k).(type) {
+		case string:
+			cloned := make([]string, len(keys))
+			for i := range keys {
+				cloned[i] = fmt.Sprint(keys[i])
+			}
+			// Can't return cloned directly because it has type []string, not
+			// []K. So jump through some unsafe hoops.
+			return unsafe.Slice((*K)(unsafe.Pointer(unsafe.SliceData(cloned))), len(cloned))
+		}
+		return keys
 	}
-	b.ResetTimer()
-	var ok bool
-	for i := 0; i < b.N; i++ {
-		_, ok = m[keys[uint32(i)&mod]]
-	}
-	assert.True(b, ok)
-	// b.ReportAllocs()
+
+	b.Run("Get", func(b *testing.B) {
+		m := make(map[K]K, n)
+		for _, k := range keys {
+			m[k] = k
+		}
+		lookupKeys := cloneKeys(keys)
+
+		b.ResetTimer()
+		var ok bool
+		for i := 0; i < b.N; i++ {
+			_, ok = m[lookupKeys[uint32(i)%n]]
+		}
+		assert.True(b, ok)
+	})
+
+	// Rather than benchmark puts and deletes separately, we benchmark them
+	// together so the map stays a constant size.
+	b.Run("PutDelete", func(b *testing.B) {
+		m := make(map[K]K, n)
+		for _, k := range keys {
+			m[k] = k
+		}
+		deleteKeys := cloneKeys(keys)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			j := uint32(i) % n
+			delete(m, deleteKeys[j])
+			m[keys[j]] = keys[j]
+		}
+	})
 }
 
 func benchmarkSwissMap[K comparable](b *testing.B, keys []K) {
 	n := uint32(len(keys))
-	mod := n - 1 // power of 2 fast modulus
-	require.Equal(b, 1, bits.OnesCount32(n))
-	m := New[K, K](len(keys))
-	for _, k := range keys {
-		m.Put(k, k)
-	}
 
-	b.ResetTimer()
-	var ok bool
-	for i := 0; i < b.N; i++ {
-		_, ok = m.Get(keys[uint32(i)&mod])
-	}
-	b.StopTimer()
+	b.Run("Get", func(b *testing.B) {
+		m := New[K, K](len(keys))
+		for _, k := range keys {
+			m.Put(k, k)
+		}
 
-	assert.True(b, ok)
-	b.ReportMetric(float64(m.Len())/float64(m.capacity), "load-factor")
-	// b.ReportAllocs()
-}
+		b.ResetTimer()
+		var ok bool
+		for i := 0; i < b.N; i++ {
+			_, ok = m.Get(keys[uint32(i)%n])
+		}
+		b.StopTimer()
 
-func genStringData(size, count int) (keys []string) {
-	src := rand.New(rand.NewSource(int64(size * count)))
-	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	r := make([]rune, size*count)
-	for i := range r {
-		r[i] = letters[src.Intn(len(letters))]
-	}
-	keys = make([]string, count)
-	for i := range keys {
-		keys[i] = string(r[:size])
-		r = r[size:]
-	}
-	return
-}
+		assert.True(b, ok)
+		b.ReportMetric(float64(m.Len())/float64(m.capacity), "load-factor")
+	})
 
-func genInt64Data(n int) (data []int64) {
-	data = make([]int64, n)
-	var x int64
-	for i := range data {
-		x += rand.Int63n(128) + 1
-		data[i] = x
-	}
-	return
+	// Rather than benchmark puts and deletes separately, we benchmark them
+	// together so the map stays a constant size.
+	b.Run("PutDelete", func(b *testing.B) {
+		m := New[K, K](len(keys))
+		for _, k := range keys {
+			m.Put(k, k)
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			j := uint32(i) % n
+			m.Delete(keys[j])
+			m.Put(keys[j], keys[j])
+		}
+		b.StopTimer()
+
+		b.ReportMetric(float64(m.Len())/float64(m.capacity), "load-factor")
+	})
 }


### PR DESCRIPTION
```
name                                         old time/op  new time/op  delta
StringMap/avgLoad,n=10/Map/Get-10            9.53ns ± 6%  8.43ns ± 1%  -11.50%  (p=0.000 n=10+9)
StringMap/maxLoad,n=13/Map/Get-10            10.0ns ± 2%   9.2ns ±26%   -8.35%  (p=0.008 n=8+10)
StringMap/minLoad,n=14/Map/Get-10            9.10ns ± 4%  8.40ns ± 0%   -7.65%  (p=0.000 n=9+8)
StringMap/avgLoad,n=83/Map/Get-10            11.0ns ± 9%   9.2ns ±11%  -16.57%  (p=0.000 n=10+10)
StringMap/maxLoad,n=111/Map/Get-10           11.1ns ± 7%   9.8ns ±10%  -11.34%  (p=0.000 n=10+10)
StringMap/minLoad,n=112/Map/Get-10           11.5ns ± 9%   8.5ns ± 4%  -25.56%  (p=0.000 n=10+10)
StringMap/avgLoad,n=671/Map/Get-10           15.7ns ± 3%   9.0ns ± 3%  -42.31%  (p=0.000 n=10+10)
StringMap/maxLoad,n=895/Map/Get-10           16.8ns ± 2%  10.3ns ± 3%  -38.98%  (p=0.000 n=10+10)
StringMap/minLoad,n=896/Map/Get-10           16.7ns ± 5%   8.6ns ± 2%  -48.90%  (p=0.000 n=10+10)
StringMap/avgLoad,n=5375/Map/Get-10          25.8ns ± 1%   9.3ns ± 1%  -63.88%  (p=0.000 n=10+10)
StringMap/maxLoad,n=7167/Map/Get-10          25.1ns ± 1%  11.2ns ± 1%  -55.28%  (p=0.000 n=9+8)
StringMap/minLoad,n=7168/Map/Get-10          25.2ns ± 1%   8.9ns ± 1%  -64.77%  (p=0.000 n=10+10)
StringMap/avgLoad,n=86015/Map/Get-10         30.5ns ± 1%  10.9ns ± 2%  -64.34%  (p=0.000 n=9+10)
StringMap/maxLoad,n=114687/Map/Get-10        32.4ns ± 1%  13.7ns ± 1%  -57.65%  (p=0.000 n=10+9)
StringMap/minLoad,n=114688/Map/Get-10        32.5ns ± 1%  14.7ns ± 2%  -54.82%  (p=0.000 n=10+10)
Int64Map/avgLoad,n=10/Map/Get-10             5.11ns ± 3%  4.85ns ± 1%   -5.13%  (p=0.000 n=10+10)
Int64Map/maxLoad,n=13/Map/Get-10             5.39ns ± 6%  4.94ns ± 2%   -8.34%  (p=0.000 n=10+10)
Int64Map/minLoad,n=14/Map/Get-10             4.86ns ± 3%  4.83ns ± 0%     ~     (p=0.796 n=10+10)
Int64Map/avgLoad,n=83/Map/Get-10             5.23ns ± 3%  5.18ns ± 7%     ~     (p=0.529 n=10+10)
Int64Map/maxLoad,n=111/Map/Get-10            4.94ns ± 1%  5.38ns ±10%   +8.85%  (p=0.000 n=10+10)
Int64Map/minLoad,n=112/Map/Get-10            5.10ns ± 5%  4.99ns ± 5%     ~     (p=0.247 n=10+10)
Int64Map/avgLoad,n=671/Map/Get-10            6.03ns ± 7%  5.36ns ± 5%  -11.08%  (p=0.000 n=10+10)
Int64Map/maxLoad,n=895/Map/Get-10            6.42ns ± 8%  5.62ns ± 3%  -12.48%  (p=0.000 n=10+10)
Int64Map/minLoad,n=896/Map/Get-10            6.21ns ± 5%  5.06ns ± 6%  -18.53%  (p=0.000 n=10+10)
Int64Map/avgLoad,n=5375/Map/Get-10           18.3ns ± 2%   5.7ns ± 2%  -68.76%  (p=0.000 n=10+10)
Int64Map/maxLoad,n=7167/Map/Get-10           18.9ns ± 1%   6.4ns ± 3%  -66.11%  (p=0.000 n=10+10)
Int64Map/minLoad,n=7168/Map/Get-10           18.8ns ± 2%   5.4ns ± 1%  -71.16%  (p=0.000 n=10+10)
Int64Map/avgLoad,n=86015/Map/Get-10          23.9ns ± 1%   6.9ns ± 0%  -71.24%  (p=0.000 n=10+9)
Int64Map/maxLoad,n=114687/Map/Get-10         22.6ns ± 1%   9.4ns ± 1%  -58.58%  (p=0.000 n=9+9)
Int64Map/minLoad,n=114688/Map/Get-10         22.6ns ± 1%   6.7ns ± 1%  -70.19%  (p=0.000 n=10+10)

name                                         old time/op  new time/op  delta
StringMap/avgLoad,n=10/Map/PutDelete-10      26.3ns ±11%  23.3ns ± 2%  -11.41%  (p=0.000 n=10+8)
StringMap/maxLoad,n=13/Map/PutDelete-10      27.4ns ± 9%  23.8ns ± 4%  -12.84%  (p=0.000 n=10+9)
StringMap/minLoad,n=14/Map/PutDelete-10      25.0ns ±10%  23.5ns ± 3%   -5.98%  (p=0.001 n=10+9)
StringMap/avgLoad,n=83/Map/PutDelete-10      31.6ns ± 7%  23.4ns ± 4%  -25.94%  (p=0.000 n=10+10)
StringMap/maxLoad,n=111/Map/PutDelete-10     31.2ns ± 4%  23.6ns ± 3%  -24.30%  (p=0.000 n=10+10)
StringMap/minLoad,n=112/Map/PutDelete-10     31.0ns ± 3%  23.6ns ± 4%  -23.60%  (p=0.000 n=10+10)
StringMap/avgLoad,n=671/Map/PutDelete-10     45.2ns ± 1%  23.5ns ± 1%  -47.96%  (p=0.000 n=10+9)
StringMap/maxLoad,n=895/Map/PutDelete-10     44.8ns ± 2%  23.2ns ± 1%  -48.23%  (p=0.000 n=10+7)
StringMap/minLoad,n=896/Map/PutDelete-10     44.6ns ± 2%  23.6ns ± 2%  -47.11%  (p=0.000 n=10+8)
StringMap/avgLoad,n=5375/Map/PutDelete-10    56.7ns ± 1%  24.3ns ± 3%  -57.25%  (p=0.000 n=10+10)
StringMap/maxLoad,n=7167/Map/PutDelete-10    53.1ns ± 1%  25.1ns ± 5%  -52.71%  (p=0.000 n=10+10)
StringMap/minLoad,n=7168/Map/PutDelete-10    53.2ns ± 1%  24.9ns ± 1%  -53.22%  (p=0.000 n=10+8)
StringMap/avgLoad,n=86015/Map/PutDelete-10   60.9ns ± 0%  38.9ns ± 3%  -36.17%  (p=0.000 n=9+10)
StringMap/maxLoad,n=114687/Map/PutDelete-10  62.4ns ± 2%  42.2ns ± 0%  -32.32%  (p=0.000 n=10+7)
StringMap/minLoad,n=114688/Map/PutDelete-10  62.7ns ± 1%  42.1ns ± 1%  -32.82%  (p=0.000 n=10+10)
Int64Map/avgLoad,n=10/Map/PutDelete-10       18.4ns ± 9%  15.8ns ±12%  -13.99%  (p=0.000 n=10+10)
Int64Map/maxLoad,n=13/Map/PutDelete-10       19.4ns ± 2%  15.6ns ± 7%  -19.61%  (p=0.000 n=8+9)
Int64Map/minLoad,n=14/Map/PutDelete-10       16.8ns ± 9%  15.0ns ± 4%  -10.85%  (p=0.000 n=9+10)
Int64Map/avgLoad,n=83/Map/PutDelete-10       19.6ns ± 4%  14.7ns ± 1%  -25.14%  (p=0.000 n=9+8)
Int64Map/maxLoad,n=111/Map/PutDelete-10      18.7ns ± 7%  14.5ns ± 2%  -22.64%  (p=0.000 n=10+10)
Int64Map/minLoad,n=112/Map/PutDelete-10      18.4ns ± 4%  14.4ns ± 3%  -21.65%  (p=0.000 n=10+10)
Int64Map/avgLoad,n=671/Map/PutDelete-10      27.1ns ± 2%  14.2ns ± 3%  -47.52%  (p=0.000 n=10+9)
Int64Map/maxLoad,n=895/Map/PutDelete-10      27.7ns ± 1%  14.3ns ± 2%  -48.26%  (p=0.000 n=9+10)
Int64Map/minLoad,n=896/Map/PutDelete-10      27.7ns ± 2%  14.2ns ± 2%  -48.62%  (p=0.000 n=10+10)
Int64Map/avgLoad,n=5375/Map/PutDelete-10     44.4ns ± 1%  16.0ns ± 2%  -63.93%  (p=0.000 n=10+8)
Int64Map/maxLoad,n=7167/Map/PutDelete-10     43.0ns ± 1%  17.1ns ± 5%  -60.31%  (p=0.000 n=10+10)
Int64Map/minLoad,n=7168/Map/PutDelete-10     43.0ns ± 1%  16.9ns ± 3%  -60.68%  (p=0.000 n=10+10)
Int64Map/avgLoad,n=86015/Map/PutDelete-10    50.6ns ± 0%  21.6ns ± 3%  -57.41%  (p=0.000 n=9+10)
Int64Map/maxLoad,n=114687/Map/PutDelete-10   47.3ns ± 0%  21.8ns ± 2%  -53.89%  (p=0.000 n=8+9)
Int64Map/minLoad,n=114688/Map/PutDelete-10   47.4ns ± 1%  22.1ns ± 3%  -53.39%  (p=0.000 n=10+10)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/swiss/3)
<!-- Reviewable:end -->
