### PR TITLE
swiss: allow configuration of the hash function and memory allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,5 @@ Int64Map/avgLoad,n=86015/Map/PutDelete-10    50.8ns ± 0%  21.0ns ± 1%  -58.65%
     Abseil implementation is leveraring gcc/llvm assembly intrinsics which are
     not currently available in Go. In order to take advantage of SIMD we'll
     have to write most/all of the probing loop in assembly.
-- Abstract out the slice allocations so we can use manual memory allocation
-  when used inside Pebble.
 - Explore extendible hashing to allow incremental resizing. See
   https://github.com/golang/go/issues/54766#issuecomment-1233125048

--- a/options.go
+++ b/options.go
@@ -1,0 +1,74 @@
+package swiss
+
+import "unsafe"
+
+// option provide an interface to do work on Map while it is being created.
+type option[K comparable, V any] interface {
+	apply(m *Map[K, V])
+}
+
+type hashOption[K comparable, V any] struct {
+	hash func(key *K, seed uintptr) uintptr
+}
+
+func (op hashOption[K, V]) apply(m *Map[K, V]) {
+	m.hash = *(*hashFn)(noescape(unsafe.Pointer(&op.hash)))
+}
+
+// WithHash is an option to specify the hash function to use for a Map[K,V].
+func WithHash[K comparable, V any](hash func(key *K, seed uintptr) uintptr) option[K, V] {
+	return hashOption[K, V]{hash}
+}
+
+// Allocator specifies an interface for allocating and releasing memory used
+// by a Map. The default allocator utilizes Go's builtin make() and allows the
+// GC to reclaim memory.
+//
+// If the allocator is manually managing memory and requires that slots and
+// controls be freed then Map.Close must be called in order to ensure
+// FreeSlots and FreeControls are called.
+type Allocator[K comparable, V any] interface {
+	// AllocSlots should return a slice equivalent to make([]Slot[K,V], n).
+	AllocSlots(n int) []Slot[K, V]
+
+	// AllocControls should return a slice equivalent to make([]uint8, n).
+	AllocControls(n int) []uint8
+
+	// FreeSlots can optional release the memory associated with the supplied
+	// slice that is guaranteed to have been allocated by AllocSlots.
+	FreeSlots(v []Slot[K, V])
+
+	// FreeControls can optional release the memory associated with the
+	// supplied slice that is guaranteed to have been allocated by
+	// AllocControls.
+	FreeControls(v []uint8)
+}
+
+type defaultAllocator[K comparable, V any] struct{}
+
+func (defaultAllocator[K, V]) AllocSlots(n int) []Slot[K, V] {
+	return make([]Slot[K, V], n)
+}
+
+func (defaultAllocator[K, V]) AllocControls(n int) []uint8 {
+	return make([]uint8, n)
+}
+
+func (defaultAllocator[K, V]) FreeSlots(v []Slot[K, V]) {
+}
+
+func (defaultAllocator[K, V]) FreeControls(v []uint8) {
+}
+
+type allocatorOption[K comparable, V any] struct {
+	allocator Allocator[K, V]
+}
+
+func (op allocatorOption[K, V]) apply(m *Map[K, V]) {
+	m.allocator = op.allocator
+}
+
+// WithAllocator is an option for specify the Allocator to use for a Map[K,V].
+func WithAllocator[K comparable, V any](allocator Allocator[K, V]) option[K, V] {
+	return allocatorOption[K, V]{allocator}
+}

--- a/runtime_go1.20.go
+++ b/runtime_go1.20.go
@@ -15,7 +15,7 @@ import "unsafe"
 //go:linkname fastrand64 runtime.fastrand64
 func fastrand64() uint64
 
-type hashfn func(unsafe.Pointer, uintptr) uintptr
+type hashFn func(key unsafe.Pointer, seed uintptr) uintptr
 
 // getRuntimeHasher peeks inside the internals of map[K]struct{} and extracts
 // the function the runtime generated for hashing type K. This is a bit hacky,
@@ -31,7 +31,7 @@ type hashfn func(unsafe.Pointer, uintptr) uintptr
 //
 // https://github.com/dolthub/maphash provided the inspiration and general
 // implementation technique.
-func getRuntimeHasher[K comparable]() hashfn {
+func getRuntimeHasher[K comparable]() hashFn {
 	a := any((map[K]struct{})(nil))
 	return (*rtEface)(unsafe.Pointer(&a)).typ.Hasher
 }


### PR DESCRIPTION
Add `WithHash` and `WithAllocator` options that can configure the hash function to use and a custom memory allocator that can enable manual management of the memory allocated by a `swiss.Map`.