### PR TITLE
tbitset comments and improvements

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -102,7 +102,7 @@ func TestMatchH2(t *testing.T) {
 	ctrls := []ctrl{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}
 	for i := uintptr(1); i <= 8; i++ {
 		match := ctrls[0].matchH2(i)
-		bit := match.next()
+		bit := match.first()
 		require.EqualValues(t, i-1, bit)
 	}
 }
@@ -121,9 +121,9 @@ func TestMatchEmpty(t *testing.T) {
 			match := c.ctrls[0].matchEmpty()
 			var results []uintptr
 			for match != 0 {
-				bit := match.next()
-				results = append(results, bit)
-				match = match.clear(bit)
+				idx := match.first()
+				results = append(results, idx)
+				match = match.remove(idx)
 			}
 			require.Equal(t, c.expected, results)
 		})
@@ -143,9 +143,9 @@ func TestMatchEmptyOrDeleted(t *testing.T) {
 			match := c.ctrls[0].matchEmptyOrDeleted()
 			var results []uintptr
 			for match != 0 {
-				bit := match.next()
-				results = append(results, bit)
-				match = match.clear(bit)
+				idx := match.first()
+				results = append(results, idx)
+				match = match.remove(idx)
 			}
 			require.Equal(t, c.expected, results)
 		})
@@ -176,6 +176,28 @@ func TestConvertNonFullToEmptyAndFullToDeleted(t *testing.T) {
 		ctrls[0].convertNonFullToEmptyAndFullToDeleted()
 		require.EqualValues(t, expected, ctrls)
 	}
+}
+
+func TestAbsentAt(t *testing.T) {
+	testCases := []struct {
+		ctrls []ctrl
+		start uintptr
+		end   uintptr
+	}{
+		{ctrls: []ctrl{0, ctrlEmpty, 0, 0, ctrlEmpty, ctrlEmpty, 0, 0}, start: 1, end: 2},
+		{ctrls: []ctrl{ctrlEmpty, ctrlEmpty, 0, 0, ctrlEmpty, 0, 0, 0}, start: 0, end: 3},
+		{ctrls: []ctrl{0, 0, 0, 0, ctrlEmpty, 0, 0, ctrlEmpty}, start: 4, end: 0},
+		{ctrls: []ctrl{ctrlEmpty, 0, 0, 0, ctrlEmpty, 0, 0, ctrlEmpty}, start: 0, end: 0},
+		{ctrls: []ctrl{0, 0, 0, 0, 0, 0, 0, 0}, start: 8, end: 8},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			match := c.ctrls[0].matchEmpty()
+			require.Equal(t, c.start, match.absentAtStart())
+			require.Equal(t, c.end, match.absentAtEnd())
+		})
+	}
+
 }
 
 func TestWasNeverFull(t *testing.T) {


### PR DESCRIPTION
This commit clarifies that `bitset` represents a set of slots within a group and abstracts usage around it without focusing on the representation. We also move the leading/trailing calculation as methods and add tests.