### PR TITLE
swiss: report performance counters in benchmarks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         go:
-          - '1.20'
           - '1.21'
           - '1.22'
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"strconv"
 	"testing"
+
+	"github.com/aclements/go-perfevent/perfbench"
 )
 
 func BenchmarkMapIter(b *testing.B) {
@@ -165,12 +167,15 @@ func genKeys[T benchTypes](start, end int) []T {
 }
 
 func benchmarkRuntimeMapIter[T benchTypes](b *testing.B, n int, genKeys func(start, end int) []T) {
+	c := perfbench.Open(b)
+
 	m := make(map[T]T, n)
 	keys := genKeys(0, n)
 	for _, k := range keys {
 		m[k] = k
 	}
 	b.ResetTimer()
+	c.Reset()
 	var tmp T
 	for i := 0; i < b.N; i++ {
 		for k, v := range m {
@@ -180,12 +185,15 @@ func benchmarkRuntimeMapIter[T benchTypes](b *testing.B, n int, genKeys func(sta
 }
 
 func benchmarkSwissMapIter[T benchTypes](b *testing.B, n int, genKeys func(start, end int) []T) {
+	c := perfbench.Open(b)
+
 	m := New[T, T](n)
 	keys := genKeys(0, n)
 	for _, k := range keys {
 		m.Put(k, k)
 	}
 	b.ResetTimer()
+	c.Reset()
 	var tmp T
 	for i := 0; i < b.N; i++ {
 		m.All(func(k, v T) bool {
@@ -198,6 +206,8 @@ func benchmarkSwissMapIter[T benchTypes](b *testing.B, n int, genKeys func(start
 func benchmarkRuntimeMapGetMiss[T benchTypes](
 	b *testing.B, n int, genKeys func(start, end int) []T,
 ) {
+	c := perfbench.Open(b)
+
 	m := make(map[T]T)
 	keys := genKeys(0, n)
 	miss := genKeys(-n, 0)
@@ -205,12 +215,15 @@ func benchmarkRuntimeMapGetMiss[T benchTypes](
 		m[k] = k
 	}
 	b.ResetTimer()
+	c.Reset()
 	for i := 0; i < b.N; i++ {
 		_ = m[miss[i%len(miss)]]
 	}
 }
 
 func benchmarkSwissMapGetMiss[T comparable](b *testing.B, n int, genKeys func(start, end int) []T) {
+	c := perfbench.Open(b)
+
 	m := New[T, T](0)
 	keys := genKeys(0, n)
 	miss := genKeys(-n, 0)
@@ -218,10 +231,12 @@ func benchmarkSwissMapGetMiss[T comparable](b *testing.B, n int, genKeys func(st
 		m.Put(keys[j], keys[j])
 	}
 	b.ResetTimer()
+	c.Reset()
 	var ok bool
 	for i := 0; i < b.N; i++ {
 		_, ok = m.Get(miss[i%len(miss)])
 	}
+	c.Stop()
 	b.StopTimer()
 	fmt.Fprint(io.Discard, ok)
 
@@ -240,6 +255,8 @@ func benchmarkSwissMapGetMiss[T comparable](b *testing.B, n int, genKeys func(st
 func benchmarkRuntimeMapGetHit[T benchTypes](
 	b *testing.B, n int, genKeys func(start, end int) []T,
 ) {
+	c := perfbench.Open(b)
+
 	m := make(map[T]T, n)
 	keys := genKeys(0, n)
 	for _, k := range keys {
@@ -254,22 +271,27 @@ func benchmarkRuntimeMapGetHit[T benchTypes](
 	keys = genKeys(0, n)
 
 	b.ResetTimer()
+	c.Reset()
 	for i := 0; i < b.N; i++ {
 		_ = m[keys[i%n]]
 	}
 }
 
 func benchmarkSwissMapGetHit[T benchTypes](b *testing.B, n int, genKeys func(start, end int) []T) {
+	c := perfbench.Open(b)
+
 	m := New[T, T](n)
 	keys := genKeys(0, n)
 	for _, k := range keys {
 		m.Put(k, k)
 	}
 	b.ResetTimer()
+	c.Reset()
 	var ok bool
 	for i := 0; i < b.N; i++ {
 		_, ok = m.Get(keys[i%n])
 	}
+	c.Stop()
 	b.StopTimer()
 	fmt.Fprint(io.Discard, ok)
 }
@@ -277,8 +299,11 @@ func benchmarkSwissMapGetHit[T benchTypes](b *testing.B, n int, genKeys func(sta
 func benchmarkRuntimeMapPutGrow[T benchTypes](
 	b *testing.B, n int, genKeys func(start, end int) []T,
 ) {
+	c := perfbench.Open(b)
+
 	keys := genKeys(0, n)
 	b.ResetTimer()
+	c.Reset()
 	for i := 0; i < b.N; i++ {
 		m := make(map[T]T)
 		for _, k := range keys {
@@ -288,9 +313,12 @@ func benchmarkRuntimeMapPutGrow[T benchTypes](
 }
 
 func benchmarkSwissMapPutGrow[T benchTypes](b *testing.B, n int, genKeys func(start, end int) []T) {
+	c := perfbench.Open(b)
+
 	var m Map[T, T]
 	keys := genKeys(0, n)
 	b.ResetTimer()
+	c.Reset()
 	for i := 0; i < b.N; i++ {
 		m.Init(0)
 		for _, k := range keys {
@@ -302,8 +330,11 @@ func benchmarkSwissMapPutGrow[T benchTypes](b *testing.B, n int, genKeys func(st
 func benchmarkRuntimeMapPutPreAllocate[T benchTypes](
 	b *testing.B, n int, genKeys func(start, end int) []T,
 ) {
+	c := perfbench.Open(b)
+
 	keys := genKeys(0, n)
 	b.ResetTimer()
+	c.Reset()
 	for i := 0; i < b.N; i++ {
 		m := make(map[T]T, n)
 		for _, k := range keys {
@@ -315,9 +346,12 @@ func benchmarkRuntimeMapPutPreAllocate[T benchTypes](
 func benchmarkSwissMapPutPreAllocate[T benchTypes](
 	b *testing.B, n int, genKeys func(start, end int) []T,
 ) {
+	c := perfbench.Open(b)
+
 	var m Map[T, T]
 	keys := genKeys(0, n)
 	b.ResetTimer()
+	c.Reset()
 	for i := 0; i < b.N; i++ {
 		m.Init(n)
 		for _, k := range keys {
@@ -329,9 +363,12 @@ func benchmarkSwissMapPutPreAllocate[T benchTypes](
 func benchmarkRuntimeMapPutReuse[T benchTypes](
 	b *testing.B, n int, genKeys func(start, end int) []T,
 ) {
+	c := perfbench.Open(b)
+
 	m := make(map[T]T, n)
 	keys := genKeys(0, n)
 	b.ResetTimer()
+	c.Reset()
 	for i := 0; i < b.N; i++ {
 		for _, k := range keys {
 			m[k] = k
@@ -345,9 +382,12 @@ func benchmarkRuntimeMapPutReuse[T benchTypes](
 func benchmarkSwissMapPutReuse[T benchTypes](
 	b *testing.B, n int, genKeys func(start, end int) []T,
 ) {
+	c := perfbench.Open(b)
+
 	m := New[T, T](n)
 	keys := genKeys(0, n)
 	b.ResetTimer()
+	c.Reset()
 	for i := 0; i < b.N; i++ {
 		for _, k := range keys {
 			m.Put(k, k)
@@ -359,12 +399,15 @@ func benchmarkSwissMapPutReuse[T benchTypes](
 func benchmarkRuntimeMapPutDelete[T benchTypes](
 	b *testing.B, n int, genKeys func(start, end int) []T,
 ) {
+	c := perfbench.Open(b)
+
 	m := make(map[T]T, n)
 	keys := genKeys(0, n)
 	for _, k := range keys {
 		m[k] = k
 	}
 	b.ResetTimer()
+	c.Reset()
 	for i := 0; i < b.N; i++ {
 		j := i % n
 		delete(m, keys[j])
@@ -375,12 +418,15 @@ func benchmarkRuntimeMapPutDelete[T benchTypes](
 func benchmarkSwissMapPutDelete[T benchTypes](
 	b *testing.B, n int, genKeys func(start, end int) []T,
 ) {
+	c := perfbench.Open(b)
+
 	m := New[T, T](n)
 	keys := genKeys(0, n)
 	for _, k := range keys {
 		m.Put(k, k)
 	}
 	b.ResetTimer()
+	c.Reset()
 	for i := 0; i < b.N; i++ {
 		j := i % n
 		m.Delete(keys[j])

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,15 @@
 module github.com/cockroachdb/swiss
 
-go 1.20
+go 1.21
 
-require github.com/stretchr/testify v1.8.4
+require (
+	github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.17.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
+github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f h1:JjxwchlOepwsUWcQwD2mLUAGE9aCp0/ehy6yCHFBOvo=
+github.com/aclements/go-perfevent v0.0.0-20240301234650-f7843625020f/go.mod h1:tMDTce/yLLN/SK8gMOxQfnyeMeCg8KGzp0D1cbECEeo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
This adds a dependency on github.com/aclements/go-perfevent