### PR TITLE
swiss: optimize bucket init by setting control bytes simultaneously

### DIFF
--- a/map.go
+++ b/map.go
@@ -619,8 +619,8 @@ func (m *Map[K, V]) Clear() {
 	m.buckets(0, func(b *bucket[K, V]) bool {
 		for i := uint32(0); i <= b.groupMask; i++ {
 			g := b.groups.At(uintptr(i))
+			g.ctrls.SetEmpty()
 			for j := uint32(0); j < groupSize; j++ {
-				g.ctrls.Set(j, ctrlEmpty)
 				*g.slots.At(j) = slot[K, V]{}
 			}
 		}
@@ -1063,9 +1063,7 @@ func (b *bucket[K, V]) init(m *Map[K, V], newCapacity uint32) {
 
 	for i := uint32(0); i <= b.groupMask; i++ {
 		g := b.groups.At(uintptr(i))
-		for j := uint32(0); j < groupSize; j++ {
-			g.ctrls.Set(j, ctrlEmpty)
-		}
+		g.ctrls.SetEmpty()
 	}
 	b.groups.At(uintptr(b.groupMask)).ctrls.Set(groupSize-1, ctrlSentinel)
 
@@ -1496,6 +1494,11 @@ func (g *ctrlGroup) Get(i uint32) ctrl {
 // Set sets the i-th control byte.
 func (g *ctrlGroup) Set(i uint32, c ctrl) {
 	*(*ctrl)(unsafe.Add(unsafe.Pointer(g), i)) = c
+}
+
+// SetEmpty sets all the control bytes to empty.
+func (g *ctrlGroup) SetEmpty() {
+	*g = ctrlGroup(bitsetEmpty)
 }
 
 // matchH2 returns the set of slots which are full and for which the 7-bit hash


### PR DESCRIPTION
This is a small optimization to set all the controls bytes in a group to empty in a single assignment when initializing a bucket or when using Clear, rather than doing so in a loop.

This saves around 2% when growing an initially empty map, at least at these sizes:

```
goos: linux
goarch: amd64
pkg: github.com/cockroachdb/swiss
cpu: Intel(R) Xeon(R) CPU @ 2.30GHz

                                   │   old       │              new                   │
                                   │   sec/op    │   sec/op     vs base               │
MapPutGrow/swissMap/Int32/6-16       205.8n ± 0%   200.4n ± 1%  -2.65% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/12-16      495.4n ± 0%   481.7n ± 0%  -2.77% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/18-16      948.5n ± 1%   910.0n ± 1%  -4.06% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/24-16      1.067µ ± 1%   1.036µ ± 0%  -2.91% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/30-16      1.847µ ± 1%   1.764µ ± 1%  -4.49% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/64-16      3.780µ ± 1%   3.591µ ± 1%  -4.99% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/128-16     7.618µ ± 3%   7.294µ ± 1%  -4.25% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/256-16     14.81µ ± 0%   14.59µ ± 1%  -1.44% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/512-16     28.90µ ± 2%   28.17µ ± 1%  -2.55% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/1024-16    56.89µ ± 0%   55.31µ ± 1%  -2.79% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/2048-16    111.8µ ± 1%   110.4µ ± 1%  -1.28% (p=0.000 n=10)
MapPutGrow/swissMap/Int32/4096-16    273.2µ ± 1%   275.5µ ± 1%  +0.82% (p=0.029 n=10)
MapPutGrow/swissMap/Int32/8192-16    613.0µ ± 1%   618.8µ ± 1%       ~ (p=0.052 n=10)
MapPutGrow/swissMap/Int32/32768-16   2.683m ± 0%   2.692m ± 0%  +0.34% (p=0.023 n=10)
MapPutGrow/swissMap/Int32/65536-16   5.552m ± 1%   5.613m ± 1%  +1.10% (p=0.002 n=10)
geomean                              20.17µ        19.75µ       -2.09%
```

Tested on a n1-standard-16 GCE VM. (Intel Haswell, and seemingly slower than the n1-standard-16 used in the README benchmarks).