### PR TITLE
swiss: optimize bit clear

### DIFF
--- a/map.go
+++ b/map.go
@@ -432,7 +432,7 @@ func (m *Map[K, V]) Put(key K, value V) {
 				b.checkInvariants(m)
 				return
 			}
-			match = match.remove(i)
+			match = match.removeFirst()
 		}
 
 		match = g.ctrls.matchEmpty()
@@ -554,7 +554,7 @@ func (m *Map[K, V]) Get(key K) (value V, ok bool) {
 			if key == slot.key {
 				return slot.value, true
 			}
-			match = match.remove(i)
+			match = match.removeFirst()
 		}
 
 		match = g.ctrls.matchEmpty()
@@ -603,7 +603,7 @@ func (m *Map[K, V]) Delete(key K) {
 				b.checkInvariants(m)
 				return
 			}
-			match = match.remove(i)
+			match = match.removeFirst()
 		}
 
 		match = g.ctrls.matchEmpty()
@@ -1456,9 +1456,9 @@ func (b bitset) first() uint32 {
 	return uint32(bits.TrailingZeros64(uint64(b))) >> 3
 }
 
-// remove removes the slot with the given relative index.
-func (b bitset) remove(i uint32) bitset {
-	return b &^ (bitset(0x80) << (i << 3))
+// removeFirst removes the first set bit (that is, resets the least significant set bit to 0).
+func (b bitset) removeFirst() bitset {
+	return b & (b - 1)
 }
 
 func (b bitset) String() string {

--- a/map_test.go
+++ b/map_test.go
@@ -130,7 +130,7 @@ func TestMatchEmpty(t *testing.T) {
 			for match != 0 {
 				idx := match.first()
 				results = append(results, idx)
-				match = match.remove(idx)
+				match = match.removeFirst()
 			}
 			require.Equal(t, c.expected, results)
 		})
@@ -152,7 +152,7 @@ func TestMatchEmptyOrDeleted(t *testing.T) {
 			for match != 0 {
 				idx := match.first()
 				results = append(results, idx)
-				match = match.remove(idx)
+				match = match.removeFirst()
 			}
 			require.Equal(t, c.expected, results)
 		})


### PR DESCRIPTION
When clearing a bit in our bitset in the inner loop of Get, Put, and Delete, we don't need to pass the index of the least significant bit we just found -- we can instead just clear the least significant bit.

Using the idiom of `b = b & (b - 1)` is simpler and faster than the current bit clearing code. This compiles down to a `BLSRQ` when building with `GOAMD64=v3`. For `GOARM=7`, it looks like it compiles to a `LEAQ -1(AX), CX` followed by `ANDQ CX, AX`.

Running the benchmarks seemed to show a geomean improvement of -1.80% sec/op on a GCE n1-standard-16 (with `GOAMD64=v3` for both old and new), but it looked a bit noisy so I don't currently entirely trust that number.