### PR TITLE
swiss: add build tag that allows building with any go version

### DIFF
--- a/runtime_go1.20.go
+++ b/runtime_go1.20.go
@@ -20,7 +20,9 @@
 // build tag "go1.20 && !go1.24" defines the range [go1.20, go1.24) (inclusive
 // on go1.20, exclusive on go1.24).
 
-//go:build go1.20 && !go1.24
+// The untested_go_version flag enables building on any go version, intended
+// to ease testing against Go at tip.
+//go:build (go1.20 && !go1.24) || untested_go_version
 
 package swiss
 


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach/issues/125104 and #35, this will allow for easier testing of new Go versions without having to manually mark them as supported. Specifically this is an [ask by the Go team](https://go-review.googlesource.com/c/benchmarks/+/588135) who would like to test Cockroach on newer versions without needing us to change the build tags each time.