### PR TITLE
swiss: update build tag to support Go 1.20 to 1.25 range

### DIFF
--- a/runtime_go1.20.go
+++ b/runtime_go1.20.go
@@ -17,12 +17,12 @@
 // bumping of the go versions supported by adjusting the build tags below. The
 // way go version tags work the tag for goX.Y will be declared for every
 // subsequent release. So go1.20 will be defined for go1.21, go1.22, etc. The
-// build tag "go1.20 && !go1.24" defines the range [go1.20, go1.24) (inclusive
-// on go1.20, exclusive on go1.24).
+// build tag "go1.20 && !go1.25" defines the range [go1.20, go1.25) (inclusive
+// on go1.20, exclusive on go1.25).
 
 // The untested_go_version flag enables building on any go version, intended
 // to ease testing against Go at tip.
-//go:build (go1.20 && !go1.24) || untested_go_version
+//go:build (go1.20 && !go1.25) || untested_go_version
 
 package swiss
 


### PR DESCRIPTION
This pull request includes a small change to the `runtime_go1.20.go` file. The change updates the Go version range supported by the build tags.

* [`runtime_go1.20.go`](diffhunk://#diff-e75a43c8acf66ebad45f9dc27c1000fd4a36c45e7a124020f929d0f14621e322L20-R25): Updated the build tag to support Go versions from 1.20 up to, but not including, 1.25.