### PR TITLE
support big endian architectures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -14,8 +15,8 @@ jobs:
           - ubuntu-latest
           - macos-latest
         go:
-          - '1.21'
           - '1.22'
+          - '1.23'
 
     runs-on: ${{ matrix.os }}
 
@@ -38,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - run: go test -v -race
 
@@ -51,6 +52,35 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - run: GOARCH=386 go test -v -tags swiss_invariants
+
+  linux-qemu-s390x:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup multiarch/qemu-user-static
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - name: ubuntu-core:s390x-focal
+        shell: bash
+        run: |
+          docker run --rm --privileged \
+            -v "${{ github.workspace }}:/swiss" \
+            multiarch/ubuntu-core:s390x-focal \
+            bash -c "
+                uname -a &&
+                lscpu | grep Endian &&
+                apt-get update &&
+                apt-get install -y wget &&
+                wget -q https://go.dev/dl/go1.23.6.linux-s390x.tar.gz &&
+                tar xzf go1.23.6.linux-s390x.tar.gz -C /usr/local &&
+                export PATH="$PATH:/usr/local/go/bin" &&
+                cd /swiss &&
+                go version &&
+                go env &&
+                go test -v ./... &&
+                go test -v -tags swiss_invariants ./...
+            "

--- a/README.md
+++ b/README.md
@@ -1250,9 +1250,6 @@ map if the map is mutated during iteration.
 
 ## Caveats
 
-- The implementation currently requires a little endian CPU architecture. This
-  is not a fundamental limitation of the implementation, merely a choice of
-  expediency.
 - Go's builtin map has a fast-path for comparing strings that [share their
   underlying
   storage](https://github.com/golang/go/blob/4a7f3ac8eb4381ea62caa1741eeeec28363245b4/src/runtime/map_faststr.go#L100).

--- a/endian_big.go
+++ b/endian_big.go
@@ -1,0 +1,20 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NB: this list of tags is taken from encoding/binary/native_endian_big.go
+//go:build armbe || arm64be || m68k || mips || mips64 || mips64p32 || ppc || ppc64 || s390 || s390x || shbe || sparc || sparc64
+
+package swiss
+
+const bigEndian = true

--- a/endian_little.go
+++ b/endian_little.go
@@ -1,0 +1,20 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NB: this list of tags is taken from encoding/binary/native_endian_little.go
+//go:build 386 || amd64 || amd64p32 || alpha || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || nios2 || ppc64le || riscv || riscv64 || sh || wasm
+
+package swiss
+
+const bigEndian = false

--- a/map_test.go
+++ b/map_test.go
@@ -182,18 +182,6 @@ func TestConvertNonFullToEmptyAndFullToDeleted(t *testing.T) {
 	}
 }
 
-func bitsetFromString(t *testing.T, str string) bitset {
-	require.Equal(t, 8, len(str))
-	var b bitset
-	for i := 0; i < 8; i++ {
-		require.True(t, str[i] == '0' || str[i] == '1')
-		if str[i] == '1' {
-			b |= 0x80 << (i * 8)
-		}
-	}
-	return b
-}
-
 func TestInitialCapacity(t *testing.T) {
 	testCases := []struct {
 		initialCapacity   int


### PR DESCRIPTION
#### remove unused function


#### support big endian architectures

The only place that needed fixing up was when we read or write
individual bytes in a control group.

We add CI for the `s390x` architecture using docker and qemu.