### PR TITLE
move ctrlGroup.Get/Set to endian_*.go

### DIFF
--- a/endian_big.go
+++ b/endian_big.go
@@ -17,4 +17,18 @@
 
 package swiss
 
+import "unsafe"
+
 const bigEndian = true
+
+// Get returns the i-th control byte.
+func (g *ctrlGroup) Get(i uint32) ctrl {
+	i = i ^ (groupSize - 1) // equivalent to (groupSize-1-i).
+	return *(*ctrl)(unsafe.Add(unsafe.Pointer(g), i))
+}
+
+// Set sets the i-th control byte.
+func (g *ctrlGroup) Set(i uint32, c ctrl) {
+	i = i ^ (groupSize - 1) // equivalent to (groupSize-1-i).
+	*(*ctrl)(unsafe.Add(unsafe.Pointer(g), i)) = c
+}

--- a/endian_little.go
+++ b/endian_little.go
@@ -17,4 +17,16 @@
 
 package swiss
 
+import "unsafe"
+
 const bigEndian = false
+
+// Get returns the i-th control byte.
+func (g *ctrlGroup) Get(i uint32) ctrl {
+	return *(*ctrl)(unsafe.Add(unsafe.Pointer(g), i))
+}
+
+// Set sets the i-th control byte.
+func (g *ctrlGroup) Set(i uint32, c ctrl) {
+	*(*ctrl)(unsafe.Add(unsafe.Pointer(g), i)) = c
+}

--- a/map.go
+++ b/map.go
@@ -1472,29 +1472,9 @@ type ctrl uint8
 
 // ctrlGroup is a fixed size array of groupSize control bytes stored in a
 // uint64.
+//
+// See Get() and Set() methods implemented in endian_*.go.
 type ctrlGroup uint64
-
-// Get returns the i-th control byte.
-func (g *ctrlGroup) Get(i uint32) ctrl {
-	if invariants && i >= groupSize {
-		panic("invalid index")
-	}
-	if bigEndian {
-		i = i ^ (groupSize - 1) // equivalent to (groupSize-1-i).
-	}
-	return *(*ctrl)(unsafe.Add(unsafe.Pointer(g), i))
-}
-
-// Set sets the i-th control byte.
-func (g *ctrlGroup) Set(i uint32, c ctrl) {
-	if invariants && i >= groupSize {
-		panic("invalid index")
-	}
-	if bigEndian {
-		i = i ^ (groupSize - 1) // equivalent to (groupSize-1-i).
-	}
-	*(*ctrl)(unsafe.Add(unsafe.Pointer(g), i)) = c
-}
 
 // SetEmpty sets all the control bytes to empty.
 func (g *ctrlGroup) SetEmpty() {


### PR DESCRIPTION
I have noticed that `if <constant>` blocks which get omitted can still
affect inlining decisions (they contribute to a complexity estimation
that happens before the block is omitted). Move the
`ctrlGroup.Get/Set` methods to the tag-dependent files and remove the
recently added invariant-only bound check.