### PR TITLE
swiss: reset hash when map becomes empty

### DIFF
--- a/map.go
+++ b/map.go
@@ -593,6 +593,12 @@ func (m *Map[K, V]) Delete(key K) {
 			if key == s.key {
 				b.used--
 				m.used--
+				if m.used == 0 {
+					// Reset the hash seed to make it more difficult for attackers to
+					// repeatedly trigger hash collisions. See issue
+					// https://github.com/golang/go/issues/25237.
+					m.seed = uintptr(fastrand64())
+				}
 				*s = slot[K, V]{}
 
 				// Only a full group can appear in the middle of a probe

--- a/map_test.go
+++ b/map_test.go
@@ -368,6 +368,20 @@ func TestIterateMutate(t *testing.T) {
 	require.EqualValues(t, e, vals)
 }
 
+func TestDeleteAll(t *testing.T) {
+	m := New[int, int](0)
+	originalSeed := m.seed
+	for i := 0; i < 100; i++ {
+		m.Put(i, i)
+	}
+	require.EqualValues(t, m.seed, originalSeed)
+
+	for i := 0; i < 100; i++ {
+		m.Delete(i)
+	}
+	require.NotEqualValues(t, m.seed, originalSeed)
+}
+
 func TestIterateDelete(t *testing.T) {
 	m := New[int, int](0)
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Basically this is a fix after the comment on the original issue. https://github.com/golang/go/issues/25237#issuecomment-686921752 

Same line can be found in the new Go 1.24 map https://github.com/golang/go/blob/2d097e363a6fce725802ecbde6d0d1b90f45290d/src/internal/runtime/maps/map.go#L664