### PR TITLE
Enable support for Go 1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
           - '1.22'
           - '1.23'
           - '1.24'
+          - '>=1.25.0-rc.1'
 
     runs-on: ${{ matrix.os }}
 
@@ -33,6 +34,11 @@ jobs:
     - run: go test -v -tags swiss_invariants
 
   linux-noswissmap:
+    strategy:
+      matrix:
+        go:
+          - '1.24'
+          - '>=1.25.0-rc.1'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -40,37 +46,52 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version:  ${{ matrix.go }}
 
       - run: GOEXPERIMENT=noswissmap go test -v
 
   linux-race:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - '1.24'
+          - '>=1.25.0-rc.1'
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version: ${{ matrix.go }}
 
       - run: go test -v -race
 
 
   linux-32bit:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - '1.24'
+          - '>=1.25.0-rc.1'
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version: ${{ matrix.go }}
 
       - run: GOARCH=386 go test -v -tags swiss_invariants
 
   linux-qemu-s390x:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - '1.24.4'
+          - '1.25rc1'
     steps:
       - uses: actions/checkout@v2
 
@@ -92,8 +113,8 @@ jobs:
                 lscpu | grep Endian &&
                 apt-get update &&
                 apt-get install -y wget &&
-                wget -q https://go.dev/dl/go1.24.0.linux-s390x.tar.gz &&
-                tar xzf go1.24.0.linux-s390x.tar.gz -C /usr/local &&
+                wget -q 'https://go.dev/dl/go${{ matrix.go }}.linux-s390x.tar.gz' &&
+                tar xzf 'go${{ matrix.go }}.linux-s390x.tar.gz' -C /usr/local &&
                 export PATH="$PATH:/usr/local/go/bin" &&
                 cd /swiss &&
                 go version &&

--- a/runtime_go1.20.go
+++ b/runtime_go1.20.go
@@ -17,12 +17,12 @@
 // bumping of the go versions supported by adjusting the build tags below. The
 // way go version tags work the tag for goX.Y will be declared for every
 // subsequent release. So go1.20 will be defined for go1.21, go1.22, etc. The
-// build tag "go1.20 && !go1.25" defines the range [go1.20, go1.25) (inclusive
-// on go1.20, exclusive on go1.25).
+// build tag "go1.20 && !go1.26" defines the range [go1.20, go1.26) (inclusive
+// on go1.20, exclusive on go1.26).
 
 // The untested_go_version flag enables building on any go version, intended
 // to ease testing against Go at tip.
-//go:build (go1.20 && !go1.25) || untested_go_version
+//go:build (go1.20 && !go1.26) || untested_go_version
 
 package swiss
 


### PR DESCRIPTION
Enables support for Go 1.25 (rc1 and later)
Runs all CI tests also on Go 1.25

Fixes #48
