### PR TITLE
Enable Go 1.26 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,8 @@ jobs:
           - '1.22'
           - '1.23'
           - '1.24'
-          - '>=1.25.0-rc.1'
+          - '1.25'
+          - '>=1.26.0-rc.1'
 
     runs-on: ${{ matrix.os }}
 
@@ -38,7 +39,8 @@ jobs:
       matrix:
         go:
           - '1.24'
-          - '>=1.25.0-rc.1'
+          - '1.25'
+          - '>=1.26.0-rc.1'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -56,7 +58,8 @@ jobs:
       matrix:
         go:
           - '1.24'
-          - '>=1.25.0-rc.1'
+          - '1.25'
+          - '>=1.26.0-rc.1'
     steps:
       - uses: actions/checkout@v2
 
@@ -74,7 +77,8 @@ jobs:
       matrix:
         go:
           - '1.24'
-          - '>=1.25.0-rc.1'
+          - '1.25'
+          - '>=1.26.0-rc.1'
     steps:
       - uses: actions/checkout@v2
 
@@ -91,7 +95,8 @@ jobs:
       matrix:
         go:
           - '1.24.4'
-          - '1.25rc1'
+          - '1.25.5'
+          - '1.26rc1'
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,6 @@ jobs:
         go:
           - '1.24'
           - '1.25'
-          - '>=1.26.0-rc.1'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/runtime_go1.20.go
+++ b/runtime_go1.20.go
@@ -17,12 +17,12 @@
 // bumping of the go versions supported by adjusting the build tags below. The
 // way go version tags work the tag for goX.Y will be declared for every
 // subsequent release. So go1.20 will be defined for go1.21, go1.22, etc. The
-// build tag "go1.20 && !go1.26" defines the range [go1.20, go1.26) (inclusive
-// on go1.20, exclusive on go1.26).
+// build tag "go1.20 && !go1.27" defines the range [go1.20, go1.27) (inclusive
+// on go1.20, exclusive on go1.27).
 
 // The untested_go_version flag enables building on any go version, intended
 // to ease testing against Go at tip.
-//go:build (go1.20 && !go1.26) || untested_go_version
+//go:build (go1.20 && !go1.27) || untested_go_version
 
 package swiss
 


### PR DESCRIPTION
Similar to
* #49 and
* #43 

Alternatively upper limit should be removed entirely or the the module even deprecated to encourage users to use swiss tables from standard library directly (https://go.dev/blog/swisstable )

Please note, that `GOEXPERIMENT=noswissmap` flag was already removed in Go 1.26, see
* https://github.com/golang/go/issues/54766
* https://go.dev/cl/691595

Incompatibility surfaced downstream in:
* https://github.com/Homebrew/homebrew-core/pull/258912

CI tests passing in test PR:
* https://github.com/stefanb/swiss/pull/2